### PR TITLE
Fixes custom item declaration

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -66,7 +66,7 @@ class ReactFormBuilder extends React.Component {
                  editMode={this.state.editMode}
                  variables={this.props.variables}
                  editElement={this.state.editElement} />
-             <Toolbar {...this.props.toolbarItems} />
+             <Toolbar {...toolbarProps} />
            </div>
          </div>
        </div>


### PR DESCRIPTION
Fixes an issue that causes the form builder not to respect passing a custom items list to the toolbar using `toolbarItems`.